### PR TITLE
chore: bump workspace-agent tag to `main-0fc0b51`

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -24,4 +24,4 @@ config:
   - so@bjerk.io
   workspace-agent:image-name: workspace-agent
   workspace-agent:reseller-topic-id: projects/partner-watch/topics/C04kw2omc
-  workspace-agent:tag: main-3eed94b
+  workspace-agent:tag: main-0fc0b51


### PR DESCRIPTION
Automated tag change. 🎉

* add docs ([commit](https://github.com/ayrorg/workspace-agent/commit/a5d9bc89de6785a450d5dc27f08698911404534e))
* refactor: improve naming and organization ([commit](https://github.com/ayrorg/workspace-agent/commit/bd77365874c8fac8b254d288c57692e25619ee9e))
* feat: Add tracing via Google Tracing ([commit](https://github.com/ayrorg/workspace-agent/commit/0fc0b512cf8f17bc318ae83e674291b238be7164))