### PR TITLE
chore: bump workspace-agent tag to `main-5efb081`

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -24,4 +24,4 @@ config:
   - so@bjerk.io
   workspace-agent:image-name: workspace-agent
   workspace-agent:reseller-topic-id: projects/partner-watch/topics/C04kw2omc
-  workspace-agent:tag: main-0fc0b51
+  workspace-agent:tag: main-5efb081


### PR DESCRIPTION
Automated tag change. 🎉

* feat: Add license warning ([commit](https://github.com/ayrorg/workspace-agent/commit/5efb08124a32dd43fae78054e974c2c790bd623f))