### PR TITLE
chore: bump workspace-agent tag to `main-0a0558f`

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -24,4 +24,4 @@ config:
   - so@bjerk.io
   workspace-agent:image-name: workspace-agent
   workspace-agent:reseller-topic-id: projects/partner-watch/topics/C04kw2omc
-  workspace-agent:tag: main-569d419
+  workspace-agent:tag: main-0a0558f


### PR DESCRIPTION
Automated tag change. 🎉

* chore(deps-dev): bump jest from 27.2.1 to 27.3.1 (indivorg/workspace-agent#40) ([commit](https://github.com/ayrorg/workspace-agent/commit/0745d466536d75381c2ffbcef3c3282544db59b5))
* chore(deps): bump date-fns from 2.24.0 to 2.25.0 (indivorg/workspace-agent#41) ([commit](https://github.com/ayrorg/workspace-agent/commit/c50e10dfae2bf320d43a86e924fa1d7e21678a90))
* chore(deps): bump nestjs-envalid from 1.2.0 to 1.2.1 (indivorg/workspace-agent#42) ([commit](https://github.com/ayrorg/workspace-agent/commit/32cb2154ad04ab3726dd26104c57b19c6d450dc5))
* chore(deps): bump slack-block-builder from 2.1.2 to 2.3.1 (indivorg/workspace-agent#45) ([commit](https://github.com/ayrorg/workspace-agent/commit/2049b4e06113d3643e1bab226567d5ec9b536d62))
* chore(deps): bump @opentelemetry/core from 1.0.0 to 1.0.1 (indivorg/workspace-agent#46) ([commit](https://github.com/ayrorg/workspace-agent/commit/d031fa9d133c0962426f32231464d4f7189c8d15))
* chore(deps): bump googleapis from 87.0.0 to 91.0.0 (indivorg/workspace-agent#44) ([commit](https://github.com/ayrorg/workspace-agent/commit/4c0e547cdcdd0240fcd7dec822c0de58c7b44c7a))
* chore(deps): bump @google-cloud/bigquery from 5.9.0 to 5.9.2 (indivorg/workspace-agent#48) ([commit](https://github.com/ayrorg/workspace-agent/commit/0a0558fd5d57fbce1fb77f73efdf3e1a415f4d76))