### PR TITLE
chore: bump workspace-agent tag to `main-dac3247`

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -14,9 +14,9 @@ config:
   google:region: europe-north1
   infra-core:deploy-service-account: org-deploy@ayr-core.iam.gserviceaccount.com
   onboarding:project: ayr-onboarding
+  onboarding:repo: onboarding
   onboarding:viewer-users:
   - so@bjerk.io
-  onboarding:repo: onboarding
   slack:bot-oauth-token:
     secure: v1:N72rOT4KbAhRwQjY:UP9yHHD7+EfIma+U+XuxeG+RLNBxYXW80zGBMJ5T3Gg6i8s7aGxhvI27xTy7PSsyIdBFJNAkEFEc/A==
   slack:webhook-url:
@@ -28,4 +28,4 @@ config:
   - so@bjerk.io
   workspace-agent:image-name: workspace-agent
   workspace-agent:reseller-topic-id: projects/partner-watch/topics/C04kw2omc
-  workspace-agent:tag: main-0a0558f
+  workspace-agent:tag: main-dac3247


### PR DESCRIPTION
Automated tag change. 🎉

* Combined Dependabot pull requests (ayrorg/workspace-agent#58) ([commit](https://github.com/ayrorg/workspace-agent/commit/77b97a1edc7eddaa93da9ccbd0e1459a7f17dd86))
* chore(deps): bump envalid from 7.2.1 to 7.2.2 (ayrorg/workspace-agent#60) ([commit](https://github.com/ayrorg/workspace-agent/commit/411733ed3655f113d0829ecfc872a205bd17904b))
* chore(deps): bump date-fns from 2.25.0 to 2.27.0 (ayrorg/workspace-agent#61) ([commit](https://github.com/ayrorg/workspace-agent/commit/56626740e4e774f7786f02e27a80dfcd40061fb9))
* chore(deps): bump @nestjs/core from 8.1.2 to 8.2.3 (ayrorg/workspace-agent#59) ([commit](https://github.com/ayrorg/workspace-agent/commit/dac3247485e47d6ef955706883192289dcd98e67))