### PR TITLE
feat: Give app engine service-account access to database secret

### DIFF
--- a/resources/core/google/app-engine.ts
+++ b/resources/core/google/app-engine.ts
@@ -1,9 +1,14 @@
 import * as gcp from '@pulumi/gcp';
+import * as pulumi from '@pulumi/pulumi';
 import { provider } from './provider';
 import { project } from './project';
 import { apiServices } from '../../google/api-services';
 import { apiServices as localApiServices } from './api-services';
 import { appEngineLocation } from '../config';
+
+export const serviceAccount = pulumi.output(
+  gcp.appengine.getDefaultServiceAccount(),
+);
 
 export const appEngine = new gcp.appengine.Application(
   'core',

--- a/resources/core/google/secrets.ts
+++ b/resources/core/google/secrets.ts
@@ -3,6 +3,7 @@ import * as pulumi from '@pulumi/pulumi';
 import { provider } from './provider';
 import { project } from './project';
 import { database, instance, user } from './sql';
+import { serviceAccount } from './app-engine';
 
 const name = 'core-database-creds';
 
@@ -24,6 +25,16 @@ export const databaseConfigSecretVersion = new gcp.secretmanager.SecretVersion(
         database: d.name,
       }),
     ),
+  },
+  { provider },
+);
+
+export const secretIam = new gcp.secretmanager.SecretIamMember(
+  'sa-secret-access',
+  {
+    member: pulumi.interpolate`serviceAccount:${serviceAccount.email}`,
+    role: 'roles/secretmanager.secretAccessor',
+    secretId: databaseConfigSecret.id,
   },
   { provider },
 );


### PR DESCRIPTION
Every service in Google uses service accounts, most of them just use a _default service account_ that is created along with the project. Default services accounts would normally have access as `role/editor`, which does give access to most services, but I don't think it gives access to secrets (seems obvious why).

This should fix ayrorg/core#36. I realized there might be more issues, like access to SQL due to missing firewall rules.