### PR TITLE
chore: bump user-api tag to `main-a5142a2`

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -30,7 +30,7 @@ config:
   slack:default-channel: C01EAPZ70RH
   slack:webhook-url:
     secure: v1:/m9K0P+/LJyWkRa1:+GWeXPKLj82nwRkjc6yp1mXtBo6mdWijknFWQ0uOkHi4BurxpNmARP37pPSM3lF958bWC+DBNMyjW6Rfr2nNK1pGe9ZidbgAR6LXhYqH77Tiu13BBq11DT8sWYJM0xY=
-  user-api:tag: main-ac23e83
+  user-api:tag: main-a5142a2
   website:main-repo: website
   website:project: ayr-website
   website:studio-repo: studio


### PR DESCRIPTION
Automated tag change. 🎉

* remove slack test message ([commit](https://github.com/ayrorg/consumer-api/commit/a5142a233799d1563c01e9fdd9b93c67a3a348c2))