### PR TITLE
chore: bump workspace-agent tag to `main-a166b7d`

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -38,4 +38,4 @@ config:
   - so@bjerk.io
   workspace-agent:image-name: workspace-agent
   workspace-agent:reseller-topic-id: projects/partner-watch/topics/C04kw2omc
-  workspace-agent:tag: main-dac3247
+  workspace-agent:tag: main-a166b7d


### PR DESCRIPTION
Automated tag change. 🎉

* fix: slack tagging ([commit](https://github.com/ayrorg/workspace-agent/commit/a166b7d915a8e114fdb9a2b52c9393abd59c020e))