### PR TITLE
chore: bump workspace-agent tag to `main-2513e31`

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -38,4 +38,4 @@ config:
   - so@bjerk.io
   workspace-agent:image-name: workspace-agent
   workspace-agent:reseller-topic-id: projects/partner-watch/topics/C04kw2omc
-  workspace-agent:tag: main-a166b7d
+  workspace-agent:tag: main-2513e31


### PR DESCRIPTION
Automated tag change. 🎉

* fix: slack references ([commit](https://github.com/ayrorg/workspace-agent/commit/2513e3151894a3ee6af0d43317fbd4b55f5116ab))