### PR TITLE
chore: bump tripletex-agent tag to `main-9ca57c8`

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -31,7 +31,7 @@ config:
   slack:default-channel: C01EAPZ70RH
   slack:webhook-url:
     secure: v1:/m9K0P+/LJyWkRa1:+GWeXPKLj82nwRkjc6yp1mXtBo6mdWijknFWQ0uOkHi4BurxpNmARP37pPSM3lF958bWC+DBNMyjW6Rfr2nNK1pGe9ZidbgAR6LXhYqH77Tiu13BBq11DT8sWYJM0xY=
-  tripletex-agent:tag: main-a40c332
+  tripletex-agent:tag: main-9ca57c8
   website:main-repo: website
   website:project: ayr-website
   website:studio-repo: studio


### PR DESCRIPTION
Automated tag change. 🎉

* fix: validation issue ([commit](https://github.com/ayrorg/tripletex-agent/commit/9ca57c8a1a5e35dababe115729145a43d6dfb484))