### PR TITLE
chore: bump consumer-api tag to `main-25f52ba`

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -4,7 +4,7 @@ config:
   console:project: ayr-console
   console:viewer-users:
   - so@bjerk.io
-  consumer-api:tag: main-8897783
+  consumer-api:tag: main-25f52ba
   core:project: ayr-core-service
   core:repo: core
   core:sql-users:


### PR DESCRIPTION
Automated tag change. 🎉

* Update README.md ([commit](https://github.com/ayrorg/consumer-api/commit/25f52bacbed2e4407811f49af1a81f947c081b56))