### PR TITLE
chore: bump tripletex-agent tag to `main-5c1cc87`

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -31,7 +31,7 @@ config:
   slack:default-channel: C01EAPZ70RH
   slack:webhook-url:
     secure: v1:/m9K0P+/LJyWkRa1:+GWeXPKLj82nwRkjc6yp1mXtBo6mdWijknFWQ0uOkHi4BurxpNmARP37pPSM3lF958bWC+DBNMyjW6Rfr2nNK1pGe9ZidbgAR6LXhYqH77Tiu13BBq11DT8sWYJM0xY=
-  tripletex-agent:tag: main-3ac2515
+  tripletex-agent:tag: main-5c1cc87
   website:main-repo: website
   website:project: ayr-website
   website:studio-repo: studio


### PR DESCRIPTION
Automated tag change. 🎉

* Replace :tada: with :moneybag: ([commit](https://github.com/ayrorg/tripletex-agent/commit/5c1cc87586ce88c1ba219bb6536fdf5a9a961eaa))