### PR TITLE
chore: bump consumer-api tag to `main-c0f99ec`

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -4,7 +4,7 @@ config:
   console:project: ayr-console
   console:viewer-users:
   - so@bjerk.io
-  consumer-api:tag: main-25f52ba
+  consumer-api:tag: main-c0f99ec
   core:project: ayr-core-service
   core:repo: core
   core:sql-users:


### PR DESCRIPTION
Automated tag change. 🎉

* chore: Change to Slack ([commit](https://github.com/ayrorg/consumer-api/commit/c0f99ecd0473776a728709a47be8e2b1b8500dd8))