### PR TITLE
chore: bump workspace-agent tag to `main-d10acd2`

### DIFF
--- a/Pulumi.prod.yaml
+++ b/Pulumi.prod.yaml
@@ -42,4 +42,4 @@ config:
   - so@bjerk.io
   workspace-agent:image-name: workspace-agent
   workspace-agent:reseller-topic-id: projects/partner-watch/topics/C04kw2omc
-  workspace-agent:tag: main-84d7e93
+  workspace-agent:tag: main-d10acd2


### PR DESCRIPTION
Automated tag change. 🎉

* move all capturing events to after Slack message ([commit](https://github.com/ayrorg/workspace-agent/commit/3bad498c3a1217300db832cef979207d6a09b909))
* fix default channel issue ([commit](https://github.com/ayrorg/workspace-agent/commit/d10acd24c4a249811e82519a5e452e53b07f123e))