### PR TITLE
feat: add OAuth Config Editor role to developers

### DIFF
--- a/resources/google/iam/iam.ts
+++ b/resources/google/iam/iam.ts
@@ -14,6 +14,10 @@ export const projectIamPolicy =
         role: 'roles/viewer',
       },
       {
+        members: developers.map((u) => interpolate`user:${u}`),
+        role: 'roles/oauthconfig.editor',
+      },
+      {
         members: [
           interpolate`serviceAccount:${calendarAgentServiceAccount.email}`,
         ],


### PR DESCRIPTION
This permission is required for setting up oauth, which I would like to do