### PR TITLE
feat: add firebase rules viewer role to developers

### DIFF
--- a/resources/google/iam/iam.ts
+++ b/resources/google/iam/iam.ts
@@ -18,6 +18,10 @@ export const projectIamPolicy =
         role: 'roles/oauthconfig.editor',
       },
       {
+        members: developers.map((u) => interpolate`user:${u}`),
+        role: 'roles/firebaserules.viewer',
+      },
+      {
         members: [
           interpolate`serviceAccount:${calendarAgentServiceAccount.email}`,
         ],


### PR DESCRIPTION
This will allow us to see the rules for access to firebase, so we can figure out how to solve #71

we need the permission `firebaserules.rulesets.get` which is avaiable in [this role](https://cloud.google.com/iam/docs/understanding-roles#firebaserules.viewer).